### PR TITLE
refactor: import JsonValue from @std/jsonc/parse

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,6 @@
     "@std/cli": "jsr:@std/cli@^0.222.1",
     "@std/fmt": "jsr:@std/fmt@^0.222.1",
     "@std/fs": "jsr:@std/fs@^0.222.1",
-    "@std/json": "jsr:@std/json@^0.222.1",
     "@std/jsonc": "jsr:@std/jsonc@^0.222.1",
     "@std/path": "jsr:@std/path@^0.222.1"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -73,7 +73,6 @@
       "jsr:@std/cli@^0.222.1",
       "jsr:@std/fmt@^0.222.1",
       "jsr:@std/fs@^0.222.1",
-      "jsr:@std/json@^0.222.1",
       "jsr:@std/jsonc@^0.222.1",
       "jsr:@std/path@^0.222.1"
     ]

--- a/install.ts
+++ b/install.ts
@@ -1,8 +1,7 @@
 import { parseArgs } from "@std/cli/parse-args";
 import { bold, green, red, setColorEnabled, yellow } from "@std/fmt/colors";
 import { ensureDir } from "@std/fs/ensure-dir";
-import type { JsonValue } from "@std/json/common";
-import { parse } from "@std/jsonc/parse";
+import { type JsonValue, parse } from "@std/jsonc/parse";
 import { join } from "@std/path/join";
 
 const hookTypes = [


### PR DESCRIPTION
Hi!

This PR changes the way to import `JsonValue` type. Currently it's imported from `@std/json/common`, but this PR changes it to import from `@std/jsonc/parse` (which exports the same `JsonValue` type)

Context: We, deno std maintainers, decided to rename `@std/json/common` to `@std/json/types` at v1. See https://github.com/denoland/deno_std/pull/5103 for details. This PR makes the future upgrade to v1 easier.